### PR TITLE
fix: a few misc fixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,9 +16,9 @@ repos:
         language: python
         types: [python]
 
-      # - id: mypy
-      #   name: mypy
-      #   entry: mypy
-      #   language: system
-      #   types: [python]
-      #   args: [--strict, --ignore-missing-imports, --exclude=tests]
+      - id: mypy
+        name: mypy
+        entry: mypy
+        language: system
+        types: [python]
+        args: [--strict, --ignore-missing-imports, --exclude=tests]

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,14 +1,24 @@
 html {
-    font-size: 16px;
-  }
+  font-size: 18px;
+}
 
-  
+
 h1 {
-  font-weight: 600 !important;
-  color: #333 !important;
+font-weight: 600 !important;
+color: #333 !important;
+}
+
+[data-md-color-scheme="slate"] h1 {
+font-weight: 600 !important;
+color: #d7d7d7 !important;
 }
 
 h2 {
-  font-weight: 600 !important;
-  color: #333 !important;
+font-weight: 600 !important;
+color: #333 !important;
+}
+
+[data-md-color-scheme="slate"] h2 {
+font-weight: 600 !important;
+color: #d7d7d7 !important;
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,8 +1,27 @@
 site_name: Batista Template Docs
+repo_url: https://github.com/batistagroup/python-template
+repo_name: batistagroup/python-template
+copyright: CC-BY 4.0 &copy; 2025 Batista Group
 theme:
   name: material
   features:
     - content.code.copy
+    - navigation.footer
+  palette:
+      # Palette toggle for light mode
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+
+    # Palette toggle for dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+
     
 extra_css:
 - stylesheets/extra.css
@@ -22,3 +41,5 @@ markdown_extensions:
   - def_list
   - pymdownx.tasklist:
       custom_checkbox: true
+  - admonition
+  - pymdownx.details

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,6 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "numpy>=2.2.3",
-    "tomli>=2.2.1",
     "tqdm>=4.67.1",
 ]
 authors = [{ name = "Anton Morgunov", email = "anton@ischemist.com" }]
@@ -18,7 +17,6 @@ Issues = "https://github.com/batistagroup/batistatemplate/issues"
 
 
 [tool.setuptools]
-packages = ["batistatemplate"]
 package-dir = { "" = "src" }
 
 
@@ -57,24 +55,3 @@ lint.select = [
     "SIM", # flake8-simplify
     "I",   # isort
 ]
-
-
-# Section below is pretty standard logger configuration
-
-[tool.logging]
-version = 1
-disable_existing_loggers = false
-
-[tool.logging.formatters.standard]
-format = "%(asctime)s [%(levelname)s] %(name)s (%(module)s:%(lineno)d): %(message)s"
-datefmt = "%Y-%m-%d %H:%M:%S"
-
-[tool.logging.handlers.console]
-class = "logging.StreamHandler"
-formatter = "standard"
-stream = "ext://sys.stdout"
-
-[tool.logging.loggers.batistatemplate]
-handlers = ["console"]
-propagate = false
-level = "INFO"

--- a/src/batistatemplate/utils/logging_config.py
+++ b/src/batistatemplate/utils/logging_config.py
@@ -1,60 +1,52 @@
 import logging
 import logging.config
 import os
-from pathlib import Path
+from typing import Any
 
-import tomli
+# --- Hardcoded Configuration ---
+LOGGING_CONFIG: dict[str, Any] = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "standard": {
+            "format": "%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+            "datefmt": "%Y-%m-%d %H:%M:%S",
+        }
+    },
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+            "formatter": "standard",
+            "stream": "ext://sys.stdout",
+        }
+    },
+    "loggers": {
+        "batistatemplate": {
+            "handlers": ["console"],
+            "propagate": False,
+            "level": "INFO",  # Default level
+        }
+    },
+}
+# --- End Hardcoded Configuration ---
 
 
 def setup_logging() -> None:
-    """Configures logging for the application.
+    """Setup logging configuration from hardcoded dict with environment variable override"""
 
-    Reads the logging configuration from the 'pyproject.toml' file
-    and applies it using `logging.config.dictConfig`.
+    # Get log level from environment variable, default to INFO if not set
+    log_level = os.getenv("BATISTATEMPLATE_LOG_LEVEL", "INFO").upper()
 
-    The log level can be overridden by setting the
-    'BATISTATEMPLATE_LOG_LEVEL' environment variable. If the environment
-    variable is not set or set to an invalid level, it defaults to 'INFO'.
-
-    Raises:
-        FileNotFoundError: If 'pyproject.toml' is not found.
-        tomli.TOMLDecodeError: If 'pyproject.toml' is not a valid TOML file.
-        KeyError: If the 'tool.logging' section is missing in 'pyproject.toml'.
-    """
-    # Construct the path to pyproject.toml, assuming it's 3 levels up from this file.
-    pyproject_path = Path(__file__).parents[3] / "pyproject.toml"
-
-    try:
-        with open(pyproject_path, "rb") as f:
-            config = tomli.load(f)
-    except FileNotFoundError as e:
-        raise FileNotFoundError(f"pyproject.toml not found at {pyproject_path}: {e}") from e
-    except tomli.TOMLDecodeError as e:
-        raise tomli.TOMLDecodeError(f"Failed to decode pyproject.toml: {e}") from e
-
-    # Determine the log level:
-    # 1. Check for BATISTATEMPLATE_LOG_LEVEL environment variable.
-    # 2. Default to 'INFO' if not set or invalid.
-    log_level_env = os.getenv("BATISTATEMPLATE_LOG_LEVEL", "INFO").upper()
-
+    # Validate the log level
     valid_levels = {"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"}
-    if log_level_env not in valid_levels:
-        print(f"Invalid log level '{log_level_env}' from environment, defaulting to INFO")
-        log_level = "INFO"
-    else:
-        log_level = log_level_env
+    if log_level not in valid_levels:
+        print(f"Invalid log level {log_level}, defaulting to INFO")
+        log_level = "INFO"  # Make sure to reset if invalid
 
-    try:
-        # Extract logging configuration from pyproject.toml
-        logging_config = config["tool"]["logging"]
-    except KeyError as e:
-        raise KeyError(f"'tool.logging' section not found in pyproject.toml: {e}") from e
+    # Override the log level in the copied config
+    LOGGING_CONFIG["loggers"]["batistatemplate"]["level"] = log_level
 
-    # Override the log level specified in pyproject.toml with the determined log level.
-    logging_config["loggers"]["batistatemplate"]["level"] = log_level
-
-    # Configure logging using the dictionary configuration.
-    logging.config.dictConfig(logging_config)
+    logging.config.dictConfig(LOGGING_CONFIG)
 
 
 # Get the logger for the 'batistatemplate' application.

--- a/uv.lock
+++ b/uv.lock
@@ -34,7 +34,6 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "numpy" },
-    { name = "tomli" },
     { name = "tqdm" },
 ]
 
@@ -64,7 +63,6 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.4" },
     { name = "rich", marker = "extra == 'dev'", specifier = ">=13.9.4" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.9.6" },
-    { name = "tomli", specifier = ">=2.2.1" },
     { name = "tqdm", specifier = ">=4.67.1" },
     { name = "types-tqdm", marker = "extra == 'dev'", specifier = ">=4.67.0.20241221" },
 ]
@@ -1076,35 +1074,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/28/e3/55dcc2cfbc3ca9c29519eb6884dd1415ecb53b0e934862d3559ddcb7e20b/stack_data-0.6.3.tar.gz", hash = "sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9", size = 44707 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl", hash = "sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695", size = 24521 },
-]
-
-[[package]]
-name = "tomli"
-version = "2.2.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/18/87/302344fed471e44a87289cf4967697d07e532f2421fdaf868a303cbae4ff/tomli-2.2.1.tar.gz", hash = "sha256:cd45e1dc79c835ce60f7404ec8119f2eb06d38b1deba146f07ced3bbc44505ff", size = 17175 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/52/e1/f8af4c2fcde17500422858155aeb0d7e93477a0d59a98e56cbfe75070fd0/tomli-2.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4a8f6e44de52d5e6c657c9fe83b562f5f4256d8ebbfe4ff922c495620a7f6cea", size = 132762 },
-    { url = "https://files.pythonhosted.org/packages/03/b8/152c68bb84fc00396b83e7bbddd5ec0bd3dd409db4195e2a9b3e398ad2e3/tomli-2.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8d57ca8095a641b8237d5b079147646153d22552f1c637fd3ba7f4b0b29167a8", size = 123453 },
-    { url = "https://files.pythonhosted.org/packages/c8/d6/fc9267af9166f79ac528ff7e8c55c8181ded34eb4b0e93daa767b8841573/tomli-2.2.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4e340144ad7ae1533cb897d406382b4b6fede8890a03738ff1683af800d54192", size = 233486 },
-    { url = "https://files.pythonhosted.org/packages/5c/51/51c3f2884d7bab89af25f678447ea7d297b53b5a3b5730a7cb2ef6069f07/tomli-2.2.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:db2b95f9de79181805df90bedc5a5ab4c165e6ec3fe99f970d0e302f384ad222", size = 242349 },
-    { url = "https://files.pythonhosted.org/packages/ab/df/bfa89627d13a5cc22402e441e8a931ef2108403db390ff3345c05253935e/tomli-2.2.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:40741994320b232529c802f8bc86da4e1aa9f413db394617b9a256ae0f9a7f77", size = 252159 },
-    { url = "https://files.pythonhosted.org/packages/9e/6e/fa2b916dced65763a5168c6ccb91066f7639bdc88b48adda990db10c8c0b/tomli-2.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:400e720fe168c0f8521520190686ef8ef033fb19fc493da09779e592861b78c6", size = 237243 },
-    { url = "https://files.pythonhosted.org/packages/b4/04/885d3b1f650e1153cbb93a6a9782c58a972b94ea4483ae4ac5cedd5e4a09/tomli-2.2.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:02abe224de6ae62c19f090f68da4e27b10af2b93213d36cf44e6e1c5abd19fdd", size = 259645 },
-    { url = "https://files.pythonhosted.org/packages/9c/de/6b432d66e986e501586da298e28ebeefd3edc2c780f3ad73d22566034239/tomli-2.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b82ebccc8c8a36f2094e969560a1b836758481f3dc360ce9a3277c65f374285e", size = 244584 },
-    { url = "https://files.pythonhosted.org/packages/1c/9a/47c0449b98e6e7d1be6cbac02f93dd79003234ddc4aaab6ba07a9a7482e2/tomli-2.2.1-cp312-cp312-win32.whl", hash = "sha256:889f80ef92701b9dbb224e49ec87c645ce5df3fa2cc548664eb8a25e03127a98", size = 98875 },
-    { url = "https://files.pythonhosted.org/packages/ef/60/9b9638f081c6f1261e2688bd487625cd1e660d0a85bd469e91d8db969734/tomli-2.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:7fc04e92e1d624a4a63c76474610238576942d6b8950a2d7f908a340494e67e4", size = 109418 },
-    { url = "https://files.pythonhosted.org/packages/04/90/2ee5f2e0362cb8a0b6499dc44f4d7d48f8fff06d28ba46e6f1eaa61a1388/tomli-2.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f4039b9cbc3048b2416cc57ab3bda989a6fcf9b36cf8937f01a6e731b64f80d7", size = 132708 },
-    { url = "https://files.pythonhosted.org/packages/c0/ec/46b4108816de6b385141f082ba99e315501ccd0a2ea23db4a100dd3990ea/tomli-2.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:286f0ca2ffeeb5b9bd4fcc8d6c330534323ec51b2f52da063b11c502da16f30c", size = 123582 },
-    { url = "https://files.pythonhosted.org/packages/a0/bd/b470466d0137b37b68d24556c38a0cc819e8febe392d5b199dcd7f578365/tomli-2.2.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a92ef1a44547e894e2a17d24e7557a5e85a9e1d0048b0b5e7541f76c5032cb13", size = 232543 },
-    { url = "https://files.pythonhosted.org/packages/d9/e5/82e80ff3b751373f7cead2815bcbe2d51c895b3c990686741a8e56ec42ab/tomli-2.2.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9316dc65bed1684c9a98ee68759ceaed29d229e985297003e494aa825ebb0281", size = 241691 },
-    { url = "https://files.pythonhosted.org/packages/05/7e/2a110bc2713557d6a1bfb06af23dd01e7dde52b6ee7dadc589868f9abfac/tomli-2.2.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e85e99945e688e32d5a35c1ff38ed0b3f41f43fad8df0bdf79f72b2ba7bc5272", size = 251170 },
-    { url = "https://files.pythonhosted.org/packages/64/7b/22d713946efe00e0adbcdfd6d1aa119ae03fd0b60ebed51ebb3fa9f5a2e5/tomli-2.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ac065718db92ca818f8d6141b5f66369833d4a80a9d74435a268c52bdfa73140", size = 236530 },
-    { url = "https://files.pythonhosted.org/packages/38/31/3a76f67da4b0cf37b742ca76beaf819dca0ebef26d78fc794a576e08accf/tomli-2.2.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:d920f33822747519673ee656a4b6ac33e382eca9d331c87770faa3eef562aeb2", size = 258666 },
-    { url = "https://files.pythonhosted.org/packages/07/10/5af1293da642aded87e8a988753945d0cf7e00a9452d3911dd3bb354c9e2/tomli-2.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a198f10c4d1b1375d7687bc25294306e551bf1abfa4eace6650070a5c1ae2744", size = 243954 },
-    { url = "https://files.pythonhosted.org/packages/5b/b9/1ed31d167be802da0fc95020d04cd27b7d7065cc6fbefdd2f9186f60d7bd/tomli-2.2.1-cp313-cp313-win32.whl", hash = "sha256:d3f5614314d758649ab2ab3a62d4f2004c825922f9e370b29416484086b264ec", size = 98724 },
-    { url = "https://files.pythonhosted.org/packages/c7/32/b0963458706accd9afcfeb867c0f9175a741bf7b19cd424230714d722198/tomli-2.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:a38aa0308e754b0e3c67e344754dff64999ff9b513e691d0e786265c93583c69", size = 109383 },
-    { url = "https://files.pythonhosted.org/packages/6e/c2/61d3e0f47e2b74ef40a68b9e6ad5984f6241a942f7cd3bbfbdbd03861ea9/tomli-2.2.1-py3-none-any.whl", hash = "sha256:cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc", size = 14257 },
 ]
 
 [[package]]


### PR DESCRIPTION
- drop packages spec from pyproj toml (otherwise only top-level package will be accessible, no submodules)
- move logger conf to a logging_conf file bc pyproj.toml is not available when published to pypi
- upd mkdocs yml to show how to link url/enable dark mode